### PR TITLE
Fix and test for updating SequenceFields

### DIFF
--- a/test/test_session.py
+++ b/test/test_session.py
@@ -23,6 +23,9 @@ class TExtraDocField(Document):
 class TExtraDocFieldList(Document):
     doclist = ListField(DocumentField(TExtra))
 
+class TIntListDoc(Document):
+    intlist = ListField(IntField())
+
 
 def test_session():
     s = Session.connect('unit-testing')
@@ -31,7 +34,7 @@ def test_session():
     s.clear()
     s.end()
 
-def test_context_manater():
+def test_context_manager():
     with Session.connect('unit-testing') as s:
         s.clear_collection(T)
         t = T(i=5)
@@ -181,3 +184,33 @@ def test_update_docfield_list_extras():
             assert doc.get_extra_fields()['j'] == 'test2'
         else:
             assert False
+
+
+def test_update_list():
+    s = Session.connect('unit-testing')
+    s.clear_collection(TIntListDoc)
+
+    tIntList = TIntListDoc(intlist=[1,2])
+    s.insert(tIntList)
+
+    # pull out of db
+    tFetched = s.query(TIntListDoc).one()
+
+    assert sorted([1,2]) == sorted(tFetched.intlist)
+
+    # append to list, update
+    l = tFetched.intlist
+    l.append(3)
+    s.update(tFetched)
+
+    # pull out of db
+    tFetched = s.query(TIntListDoc).one()
+
+    assert sorted([1,2,3]) == sorted(tFetched.intlist)
+
+    tFetched.intlist.remove(1)
+    s.update(tFetched)
+
+    tFetched = s.query(TIntListDoc).one()
+
+    assert sorted([2,3]) == sorted(tFetched.intlist)


### PR DESCRIPTION
Current code doesn't support "update" on SequenceField where the underlying python sequence is modified rather than replaced outright.  The result of the update operation is a purge of the Sequence from the db.

I've got a couple of test cases here.  I initially thought the issue was confined to SubDocument lists but determined it was not, so there are two cases, one with IntFields and the other with SubDocuments.

I'm not entirely happy with the fix I'm proposing here, which is to detect when the list fetched from the DB differs from the current list and simply replace the old list with the new one.  I suppose the "perfect" solution would be to $push and $pull the added and removed elements from the list, but only when that is more efficient that simply $setting the new list.  I know for our use case, we aren't really using lists of more than a few dozen elements of fairly small size, so simply blowing away the whole thing isn't a big deal.

The location in which I'm stuffing the old value is probably not the best place as well.  If there's a better place to cache the old value I'd be happy to move it there.
