### PR TITLE
Support for $exists

### DIFF
--- a/mongoalchemy/query_expression.py
+++ b/mongoalchemy/query_expression.py
@@ -193,6 +193,11 @@ class QueryField(object):
         return QueryExpression({
             self : { '$nin' : [self.get_type().wrap_value(value) for value in values] }
         })
+
+    def exists(self, exists=True):
+        ''' Create a MongoDB query to check if a field exists on a Document.
+        '''
+        return QueryExpression({self: {'$exists': exists}})
     
     def __str__(self):
         return self.get_absolute_name()

--- a/test/test_query_expressions.py
+++ b/test/test_query_expressions.py
@@ -241,6 +241,11 @@ def test_nin():
     assert q.nin(T.i, 1, 2, 3).query == {'i' : {'$nin' : [1,2,3]}}, q.nin(T.i, 1, 2, 3).query
     assert q.filter(T.i.nin(1, 2, 3)).query == {'i' : {'$nin' : [1,2,3]}}
 
+def test_exists():
+    q = Query(T, None)
+    assert q.filter(T.i.exists(False)).query == {'i': {'$exists': False}}
+    assert q.filter(T.i.exists(True)).query == {'i': {'$exists': True}}
+
 
 # free-form queries
 


### PR DESCRIPTION
Hello there! I'm using MongoAlchemy (more specifically, Flask-MongoAlchemy) for a project at work, and I noticed that MA doesn't have support for MongoDB's $exists queries.

Since this is rather essential to what I'm doing, I decided to add in support and tests for it.

Please review and let me know if you think anything is missing.

Patrick.
