### PR TITLE
Updated Document.__init__ field-processing conditional.

### DIFF
--- a/mongoalchemy/document.py
+++ b/mongoalchemy/document.py
@@ -215,7 +215,7 @@ class Document(object):
                 value = kwargs[name]
                 self._values[name] = Value(field, self,
                                            from_db=loading_from_db)
-                getattr(cls, name).set_value(self, kwargs[name])
+                field.set_value(self, value)
             elif field.auto:
                 self._values[name] = Value(field, self, from_db=False)
             else:


### PR DESCRIPTION
`field` and `value` were set on lines 214 and 215, but never used. Re-wrote line 218 to use those variables, rather than re-accessing the original values.
