### PR TITLE
Automatic polymorphic queries

### DIFF
--- a/mongoalchemy/query.py
+++ b/mongoalchemy/query.py
@@ -28,7 +28,7 @@ from pymongo import ASCENDING, DESCENDING
 from copy import copy, deepcopy
 
 from mongoalchemy.exceptions import BadValueException
-from mongoalchemy.query_expression import QueryExpression, BadQueryException, flatten
+from mongoalchemy.query_expression import QueryExpression, BadQueryException, flatten, FreeFormDoc
 from mongoalchemy.update_expression import UpdateExpression, FindAndModifyExpression
 from mongoalchemy.util import resolve_name
 
@@ -44,13 +44,16 @@ class Query(object):
         In general a query object should be created via ``Session.query``,
         not directly.
     '''
-    def __init__(self, type, session):
+    def __init__(self, type, session, exclude_subclasses=False):
         ''' :param type: A subclass of class:`mongoalchemy.document.Document`
             :param db: The :class:`~mongoalchemy.session.Session` which this query is associated with.
+            :param exclude_subclasses: If this is set to false (the default) and `type` \
+                is polymorphic then subclasses are also retrieved.
         '''
         self.session = session
         self.type = type
-        self.__query = {}
+
+        self.__query = type.base_query(exclude_subclasses)
         self._sort = []
         self._fields = None
         self.hints = []

--- a/mongoalchemy/query_expression.py
+++ b/mongoalchemy/query_expression.py
@@ -60,6 +60,9 @@ class FreeFormDoc(object):
     def __getattr__(self, name):
         return QueryField(FreeFormField(name))
     @classmethod
+    def base_query(*args, **kwargs):
+        return {}
+    @classmethod
     def unwrap(cls, value, *args, **kwargs):
         return value
     def get_collection_name(self):
@@ -133,11 +136,11 @@ class QueryField(object):
             **Example**: ``session.query(Spell).filter(Spells.name.startswith("abra", ignore_case=True))``
 
             .. note:: This is a shortcut to .regex('^' + re.escape(prefix))
-                MongoDB optimises such prefix expressions to use indexes 
-                appropriately. As the prefix contains no further regex, this 
+                MongoDB optimises such prefix expressions to use indexes
+                appropriately. As the prefix contains no further regex, this
                 will be optimized by matching only against the prefix.
 
-        """ 
+        """
         return self.regex('^' + re.escape(prefix), ignore_case=ignore_case, options=options)
 
     def endswith(self, suffix, ignore_case=False, options=None):

--- a/mongoalchemy/session.py
+++ b/mongoalchemy/session.py
@@ -220,7 +220,7 @@ class Session(object):
         if self.autoflush:
             return self.flush()
 
-    def query(self, type):
+    def query(self, type, exclude_subclasses=False):
         ''' Begin a query on the database's collection for `type`.  If `type`
             is an instance of basesting, the query will be in raw query mode
             which will not check field values or transform returned results
@@ -232,7 +232,7 @@ class Session(object):
         # read
         if isinstance(type, basestring):
             type = FreeFormDoc(type)
-        return Query(type, self)
+        return Query(type, self, exclude_subclasses=exclude_subclasses)
 
     def add_to_session(self, obj):
         obj._set_session(self)

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -41,6 +41,9 @@ def test_indexes():
     assert got == desired, '\nG: %s\nD: %s' % (got, desired)
 
 def expire_index_test():
+    import os
+    if os.environ.get('FAST_TESTS') == 'true':
+        return
     class TestDoc3(TestDoc):
         date = DateTimeField()
 

--- a/test/test_query_expressions.py
+++ b/test/test_query_expressions.py
@@ -266,7 +266,7 @@ def test_not():
 
 @raises(BadQueryException)
 def test_not_with_malformed_field():
-    class Any(DocumentField):
+    class Any(Document):
         i = AnythingField()
     not_q = Query(Any, None).not_(Any.i == { '$gt' : 4, 'garbage' : 5})
 

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -323,7 +323,7 @@ def test_update_docfield_extras():
     t2_new = s.query(TExtraDocField).one()
     assert t2_new.doc.i == 1
     assert t2_new.doc.get_extra_fields()['j'] == 'test'
-    assert t2_new.doc.get_extra_fields()['t'] == 'added'
+    assert t2_new.doc.get_extra_fields().get('t') == 'added', t2_new.doc.get_extra_fields()
 
 def test_update_docfield_list_extras():
     s = Session.connect('unit-testing')


### PR DESCRIPTION
This change:
* makes superclasses know about all their subclasses, even multiple levels down
* Makes the queries for polymorphic documents include an $in query for the
  config_polymorphic field with the config_polymorphic_identity for all
  subclasses
* Adds fairly good tests for this feature

resolves #138